### PR TITLE
Improve menu and UI

### DIFF
--- a/src/states/menus.py
+++ b/src/states/menus.py
@@ -209,28 +209,25 @@ class PauseMenu(State):
 class Settings(State):
     def __init__(self, background_tint_color: pg.typing.ColorLike = "#777777"):
         super().__init__()
-        self.__soundfx = elements.Slider((0, 100), int(data.get_setting("soundfx_volume")*100), 10, "Sound FX")
-        self.__soundfx.on_slide(lambda x: data.update_settings(soundfx_volume=round(x*0.01, 2)))
+        settings_elements = [
+            elements.Slider("Sound FX", (0, 100), int(data.get_setting("soundfx_volume")*100), 10,
+                            lambda x: data.update_settings(soundfx_volume=round(x*0.01, 2))),
+            elements.Slider("Music", (0, 100), int(data.get_setting("music_volume")*100), 10,
+                            lambda x: data.update_settings(music_volume=round(x*0.01, 2))),
+            elements.Toggle("Controller Rumble", data.get_setting("controller_rumble"),
+                            lambda x: data.update_settings(controller_rumble=x)),
+            elements.Toggle("Motion blur", data.get_setting("motion_blur"),
+                            lambda x: data.update_settings(motion_blur=x)),
+            elements.Toggle("Pixel blur", data.get_setting("scale_blur"),
+                            lambda x: data.update_settings(scale_blur=x)),
 
-        self.__music = elements.Slider((0, 100), int(data.get_setting("music_volume")*100), 10, "Music")
-        self.__music.on_slide(lambda x: data.update_settings(music_volume=round(x*0.01, 2)))
-        
-        self.__scale_blur = elements.Toggle(data.get_setting("scale_blur"), "Pixel blur")
-        self.__scale_blur.on_toggle(lambda x: data.update_settings(scale_blur=x))
+            elements.UIPadding(8),
 
-        self.__controller_rumble = elements.Toggle(data.get_setting("controller_rumble"), "Controller Rumble")
-        self.__motion_blur = elements.Toggle(data.get_setting("motion_blur"), "Motion blur")
-        self.__show_version_num = elements.Toggle(data.get_setting("show_version_number"), "Show version number")
+            elements.Toggle("Show version number", data.get_setting("show_version_number"),
+                            lambda x: data.update_settings(show_version_number=x)),
+        ]
 
-        self.__elements = elements.ElementList([
-            self.__music,
-            self.__soundfx,
-            self.__controller_rumble,
-            self.__motion_blur,
-            self.__scale_blur,
-            elements.UIPadding(15),
-            self.__show_version_num
-        ], wrap_list=True)
+        self.__elements = elements.ElementList(settings_elements, wrap_list=True)
 
         self.__background: pg.Surface | None = None
         self.__tint_color = background_tint_color
@@ -275,14 +272,6 @@ class Settings(State):
 
 
     def quit(self):
-        data.update_settings(
-            soundfx_volume=round(self.__soundfx.value*0.01, 2),
-            controller_rumble=self.__controller_rumble.on,
-            show_version_number=self.__show_version_num.on,
-            motion_blur=self.__motion_blur.on,
-            scale_blur=self.__scale_blur.on
-        )
-
         data.save_settings()
 
 

--- a/src/states/test_states.py
+++ b/src/states/test_states.py
@@ -1,5 +1,7 @@
 import pygame as pg
 
+from debug import Cheats
+
 from src.ui import elements, font, blit_to_center
 from src.audio.music import MusicManager
 from src.file_processing import data
@@ -15,12 +17,12 @@ class TestElementList(State):
 
         self.__elements = elements.ElementList(
             [
-                elements.Toggle(False, "Test Toggle")
-                for _ in range(6)
+                elements.Toggle(f"Test Toggle {i}", False)
+                for i in range(11)
             ]
             + [
-                elements.Slider((0, 100), 0, 10, "test Slider")
-                for _ in range(6)
+                elements.Slider(f"Test Slider {i}", (0, 100), 0, 10)
+                for i in range(0)
             ],
         wrap_list=True)
 
@@ -32,7 +34,9 @@ class TestElementList(State):
     
     def draw(self, surface, lerp_amount=0):
         surface.fill("#333333")
-        self.__elements.draw(surface)
+        subsurface = surface.subsurface(10, 10, surface.width-20, surface.height-20)
+        subsurface.fill("black")
+        self.__elements.draw(subsurface)
 
 
 
@@ -40,7 +44,7 @@ class TestMusic(State):
     def __init__(self):
         super().__init__()
         MusicManager.play("test_music")
-        self.__volume_slider = elements.Slider((0, 1), data.get_setting("music_volume"), 0.1)
+        self.__volume_slider = elements.Slider("Music Volume", (0, 1), data.get_setting("music_volume"), 0.1)
         self.__volume_slider.on_slide(lambda x: (data.update_settings(music_volume=x), MusicManager.update_music_volume()))
 
     def userinput(self, inputs):

--- a/src/ui/elements.py
+++ b/src/ui/elements.py
@@ -115,8 +115,18 @@ class UIPadding(UIElement):
 
 class Slider(UIElement):
     __size = (75, 12)
-    def __init__(self, slider_range: tuple[int, int], value: int, step=1, name: str | None = None):
+    def __init__(self,
+                 label: str,
+                 slider_range: tuple[int, int],
+                 value: int,
+                 step=1,
+                 on_slide: Callable[[float], None] | None = None):
+        
+        super().__init__(label)
         self.__min, self.__max = slider_range
+        self.__step = step
+        self.__inverse_of_range = 1/(self.__max-self.__min)
+
         if self.__max <= self.__min:
             raise ValueError("First value in range must be less than second value")
 
@@ -124,15 +134,7 @@ class Slider(UIElement):
             self.__value = value
         else:
             raise ValueError(f"Starting value must be within slider_range {slider_range}, not {value}")
-        
-        self.__inverse_of_range = 1/(self.__max-self.__min)
 
-
-        self.__step = step
-        if name is None:
-            self._label = "Slider"
-        else:
-            self._label = name
 
         texture_map = assets.load_texture_map("ui_elements")
         self.__base_texture = texture_map["slider_base"]
@@ -140,6 +142,7 @@ class Slider(UIElement):
         self.__handle_texture = texture_map["slider_handle"]
 
         self.__on_slide: Callable[[float], None] | None = None
+        self.on_slide(on_slide)
 
 
     @property
@@ -186,7 +189,7 @@ class Slider(UIElement):
 class Toggle(UIElement):
     __size = (31, 13)
 
-    def __init__(self, on=False, label: str | None = None):
+    def __init__(self, label: str, on=False, on_toggle: Callable[[bool], None] | None = None):
         super().__init__(label)
         self.__on = on
         self.__texture_map = assets.load_texture_map("ui_elements")
@@ -198,7 +201,7 @@ class Toggle(UIElement):
         self.__controller.skip_to_end()
 
         self.__on_toggle: Callable[[bool], None] | None = None
-
+        self.on_toggle(on_toggle)
 
     @property
     def size(self) -> pg.typing.Point:

--- a/src/ui/font_types.py
+++ b/src/ui/font_types.py
@@ -29,7 +29,7 @@ class Font:
             return self.__render_internal(text, size, color_a, color_b)
 
 
-    @lru_cache(8)
+    @lru_cache(32)
     def __render_cached(self, text, size, color_a, color_b) -> pg.Surface:
         return self.__render_internal(text, size, color_a, color_b)
 


### PR DESCRIPTION
Settings menu was lagging due to there being for than 8 pieces of text being rendered. Only 8 font renders were cached. Increase font cache size from 8 to 32 to resolve this issue.

Update UIElements to include call-back function in initializer and make label the first argument.