### PR TITLE
General improvements to states

### DIFF
--- a/debug.py
+++ b/debug.py
@@ -15,7 +15,7 @@ class Cheats():
     **no_obstacles** - prevents spawning of obstacles like asteroid or enemies  
     **no_point_combo** - player will gain no additional points from consecutive hits on asteroids  
     **show_bounding_boxes** - shows bounding boxes for entities  
-    **instant_respawn** - UNIMPLEMENTED  
+    **instant_restart** - UNIMPLEMENTED  
     **no_lerp** - Turns of frame interpolation
     **ignore_colorkey** - turns of colorkey transparency, this also turns off background parallax
     
@@ -35,7 +35,7 @@ class Cheats():
     no_obstacles = False
     no_point_combo = False
     show_bounding_boxes = False
-    instance_respawn = False
+    instant_restart = False
     no_lerp = False
     ignore_colorkey = False
 

--- a/src/states/__init__.py
+++ b/src/states/__init__.py
@@ -11,6 +11,7 @@ from src import game_errors
 from src.input_device import InputInterpreter
 from src.custom_types import Timer
 from src.audio.soundfx import HasSoundQueue
+from src.misc import find_subclass_by_name
 
 
 
@@ -171,7 +172,7 @@ class StateStack(HasSoundQueue):
     
 
     def push(self, state: State, transition=True) -> None:
-        "Adds a new state to the top of the stack."
+        "Add a new state to the top of the stack."
 
         self.__transition_timer.stop()
 
@@ -187,7 +188,7 @@ class StateStack(HasSoundQueue):
 
 
     def pop(self, transition=True, quit_state=True) -> State:
-        "Removes and returns the top state."
+        "Remove and return the top state."
         
         self.__transition_timer.stop()
         state = self.top_state
@@ -206,8 +207,25 @@ class StateStack(HasSoundQueue):
         
 
     def index(self, item: State) -> int:
-        "Returns the index of the current state."
+        "Return the index of the current state."
         return self.__container.index(item)
+    
+
+
+    def find_by_type[T](self, state_type: type[T]) -> T | None:
+        """Find the first state in the stack that is of the specified type"""
+        for state in self:
+            if isinstance(state, state_type):
+                return state
+        else:
+            return None
+    
+
+    def find_by_name(self, name: str) -> State | None:
+        """Find the first state in the stack with the specified name (name of State type)"""
+        state_type = find_subclass_by_name(State, name)
+        return state_type and self.find_by_type(state_type)
+
     
 
 

--- a/src/states/init_state.py
+++ b/src/states/init_state.py
@@ -5,7 +5,7 @@ from src.game_errors import SaveFileError
 from src.file_processing import data
 from src.misc import get_start_level, find_subclass_by_name
 
-from . import State, StateStack, menus, info_states, boss_level, play_level
+from . import State, StateStack, menus, info_states, boss_level, play_level, visuals
 
 from .test_states import *
 
@@ -50,12 +50,17 @@ class Initializer:
     
 
     @classmethod
-    def main_title_screen(self, state_stack: StateStack) -> None:
-        play_level.PlayLevel(get_start_level()).add_to_stack(state_stack)
+    def main_title_screen(cls, state_stack: StateStack) -> None:
+        cls.main_gameplay(state_stack)
         menus.TitleScreen().add_to_stack(state_stack)
+
+    @classmethod
+    def main_gameplay(cls, state_stack: StateStack) -> None:
+        play_level.PlayLevel(get_start_level()).add_to_stack(state_stack)
 
     
     @classmethod
-    def continue_from_save(self, state_stack: StateStack, save_data: SaveData) -> None:
+    def continue_from_save(cls, state_stack: StateStack, save_data: SaveData) -> None:
         play_level.PlayLevel.init_from_save(save_data).add_to_stack(state_stack)
+        visuals.BackgroundTint("#777777").add_to_stack(state_stack)
         menus.PauseMenu().add_to_stack(state_stack)

--- a/src/states/menus.py
+++ b/src/states/menus.py
@@ -235,6 +235,9 @@ class Settings(State):
     def userinput(self, inputs):
         if not debug.Cheats.demo_mode:
             option_to_delete_user_data(self.state_stack, inputs)
+        
+        if debug.DEBUG_MODE and inputs.check_input("settings"):
+            self.state_stack.push(DebugMenu())
 
         if inputs.check_input("back"):
             self.state_stack.pop()
@@ -270,9 +273,46 @@ class Settings(State):
             surface.blit(self.__background)
 
 
-
     def quit(self):
         data.save_settings()
+
+
+
+
+
+
+
+
+
+class DebugMenu(State):
+    def __init__(self):
+        super().__init__()
+
+        self.__elements = elements.ElementList([
+            elements.Toggle("invincible", debug.Cheats.invincible, lambda x: setattr(debug.Cheats, "invincible", x)),
+            elements.Toggle("no_obstacles", debug.Cheats.no_obstacles, lambda x: setattr(debug.Cheats, "no_obstacles", x)),
+            elements.Toggle("no_point_combo", debug.Cheats.no_point_combo, lambda x: setattr(debug.Cheats, "no_point_combo", x)),
+            elements.Toggle("show_bounding_boxes", debug.Cheats.show_bounding_boxes, lambda x: setattr(debug.Cheats, "show_bounding_boxes", x)),
+            elements.Toggle("instance_respawn", debug.Cheats.instance_respawn, lambda x: setattr(debug.Cheats, "instance_respawn", x)),
+            elements.Toggle("no_lerp", debug.Cheats.no_lerp, lambda x: setattr(debug.Cheats, "no_lerp", x)),
+        ], wrap_list=True)
+
+
+    def userinput(self, inputs):
+        if inputs.check_input("back"):
+            self.state_stack.pop()
+            return
+
+        self.__elements.userinput(inputs)
+    
+    def update(self):
+        self.__elements.update()
+    
+    def draw(self, surface, lerp_amount=0):
+        surface.fill("black")
+        surface.blit(font.large_font.render("Debug Menu"), (20, 20))
+        self.__elements.draw(surface.subsurface(20, 50, min(250, surface.width-40), max(surface.height-50, 0)))
+        surface.blit(font.icon_font.render("Back<back>"), (10, surface.height-18))
 
 
 

--- a/src/states/menus.py
+++ b/src/states/menus.py
@@ -148,12 +148,17 @@ class PauseMenu(State):
                 self.__exit_menu = True
 
             elif inputs.check_input("quit"):
-                InfoState(
-                    "Quit to Main Menu",
-                    "Are you sure you want to quit?",
-                    confirm_action=self.quit_to_main_menu,
-                    can_escape=True
-                ).add_to_stack(self.state_stack)
+                # Show confirmation menu if player has made some progress in game
+                play_state = self.state_stack.find_by_name("Play")
+                if play_state is not None and play_state.is_saving_progress:
+                    InfoState(
+                        "Quit to Main Menu",
+                        "Are you sure you want to quit?",
+                        confirm_action=self.__quit_to_main_menu,
+                        can_escape=True
+                    ).add_to_stack(self.state_stack)
+                else:
+                    self.__quit_to_main_menu()
                 
 
         
@@ -189,10 +194,13 @@ class PauseMenu(State):
         return self.prev_state.debug_info()
     
 
-    def quit_to_main_menu(self):
-        from .init_state import Initializer
+    def __quit_to_main_menu(self):
+        play_state = self.state_stack.find_by_name("Play")
+        if play_state is not None:
+            play_state.can_save_progress(False)
+
         self.state_stack.quit()
-        data.delete_progress()
+        from .init_state import Initializer
         Initializer.main_title_screen(self.state_stack)
 
     

--- a/src/states/menus.py
+++ b/src/states/menus.py
@@ -12,7 +12,7 @@ from src.ui import blit_to_center, font, effects, elements, hud
 
 from . import State, StateStack
 from .info_states import InfoState, DeleteUserDataOption
-from .visuals import add_background_tint
+from .visuals import BackgroundTint, add_background_tint
 
 
 
@@ -44,6 +44,9 @@ class TitleScreen(State):
         # race condition from the drawing thread.
         self.__info_text = pg.Surface((1, 1))
 
+        from .play import Play
+        self.prev_state: Play
+
 
 
 
@@ -68,7 +71,8 @@ class TitleScreen(State):
                     self.title.set_effect("main_exit")
                 
                 if inputs.check_input("settings"):
-                    Settings("#4E6382").add_to_stack(self.state_stack)
+                    self.state_stack.push(BackgroundTint("#4E6382"))
+                    self.state_stack.push(Settings())
     
         else:
             self.prev_state.spaceship.userinput(inputs)
@@ -124,39 +128,32 @@ class TitleScreen(State):
 
 class PauseMenu(State):
     "Shows the pause menu with the game title. This freezes the gameplay in the previous state."
-    def __init__(self, background_tint_color: pg.typing.ColorLike = "#777777"):
+    def __init__(self):
         super().__init__()
 
         self.title = effects.AnimatedText(config.WINDOW_CAPTION, "main_entrance_b")
         self.__exit_menu = False
-        self.__tint_color = background_tint_color
 
         # Assigned default values to avoid raising Attribute Errors.
         self.__info_text = pg.Surface((1, 1))
-
-        from .play import Play
-        self.prev_state: Play
 
 
 
     def userinput(self, inputs):
         if inputs.check_input("settings"):
-            Settings(self.__tint_color).add_to_stack(self.state_stack)
+            self.state_stack.push(Settings())
         elif self.title.animations_complete:
             if inputs.check_input("pause") or inputs.check_input("select") or inputs.check_input("back"):
                 self.title.set_effect("main_exit")
                 self.__exit_menu = True
 
             elif inputs.check_input("quit"):
-                if self.prev_state.is_saving_progress:
-                    InfoState(
-                        "Quit to Main Menu",
-                        "Are you sure you want to quit?",
-                        confirm_action=self.quit_to_main_menu,
-                        can_escape=True
-                    ).add_to_stack(self.state_stack)
-                else:
-                    self.quit_to_main_menu()
+                InfoState(
+                    "Quit to Main Menu",
+                    "Are you sure you want to quit?",
+                    confirm_action=self.quit_to_main_menu,
+                    can_escape=True
+                ).add_to_stack(self.state_stack)
                 
 
         
@@ -180,8 +177,6 @@ class PauseMenu(State):
         self.prev_state.draw(surface, 1)
         if not self.is_top_state():
             return
-
-        add_background_tint(surface, self.__tint_color)
         
         blit_to_center(self.title.render(lerp_amount), surface, (0, -40))
         if not self.__exit_menu:
@@ -196,8 +191,8 @@ class PauseMenu(State):
 
     def quit_to_main_menu(self):
         from .init_state import Initializer
-        self.prev_state.can_save_progress(False)
         self.state_stack.quit()
+        data.delete_progress()
         Initializer.main_title_screen(self.state_stack)
 
     
@@ -207,7 +202,7 @@ class PauseMenu(State):
 
 
 class Settings(State):
-    def __init__(self, background_tint_color: pg.typing.ColorLike = "#777777"):
+    def __init__(self):
         super().__init__()
         settings_elements = [
             elements.Slider("Sound FX", (0, 100), int(data.get_setting("soundfx_volume")*100), 10,
@@ -228,9 +223,8 @@ class Settings(State):
         ]
 
         self.__elements = elements.ElementList(settings_elements, wrap_list=True)
-
         self.__background: pg.Surface | None = None
-        self.__tint_color = background_tint_color
+
 
     def userinput(self, inputs):
         if not debug.Cheats.demo_mode:
@@ -251,7 +245,6 @@ class Settings(State):
     
     def draw(self, surface, lerp_amount=0):
         self.__draw_background(surface)
-        add_background_tint(surface, self.__tint_color)
         # self.prev_state.draw(surface)
         surface.blit(font.large_font.render("Settings"), (20, 20))
         self.__elements.draw(surface.subsurface(20, 50, min(250, surface.width-40), max(surface.height-50, 0)))
@@ -293,7 +286,7 @@ class DebugMenu(State):
             elements.Toggle("no_obstacles", debug.Cheats.no_obstacles, lambda x: setattr(debug.Cheats, "no_obstacles", x)),
             elements.Toggle("no_point_combo", debug.Cheats.no_point_combo, lambda x: setattr(debug.Cheats, "no_point_combo", x)),
             elements.Toggle("show_bounding_boxes", debug.Cheats.show_bounding_boxes, lambda x: setattr(debug.Cheats, "show_bounding_boxes", x)),
-            elements.Toggle("instance_respawn", debug.Cheats.instance_respawn, lambda x: setattr(debug.Cheats, "instance_respawn", x)),
+            elements.Toggle("instant_restart", debug.Cheats.instant_restart, lambda x: setattr(debug.Cheats, "instant_restart", x)),
             elements.Toggle("no_lerp", debug.Cheats.no_lerp, lambda x: setattr(debug.Cheats, "no_lerp", x)),
         ], wrap_list=True)
 
@@ -342,7 +335,7 @@ class GameOverScreen(State):
         self.title.update()
         if self.__timer == 0:
             self.state_stack.pop()
-            ShowScore(self.__level_name, self.__score_data).add_to_stack(self.state_stack)
+            self.state_stack.push(ShowScore(self.__level_name, self.__score_data))
         else:
             self.__timer -= 1
 
@@ -387,7 +380,7 @@ class ShowScore(State):
 
                 # Empties the state stack and adds a new Play state.
                 self.state_stack.quit()
-                PlayLevel(get_start_level()).add_to_stack(self.state_stack)
+                self.state_stack.push(PlayLevel(get_start_level()))
         
         if not self.__timer and inputs.check_input("quit"):
             from .init_state import Initializer

--- a/src/states/play.py
+++ b/src/states/play.py
@@ -13,7 +13,7 @@ from src.game_objects import (
 
 from . import State
 from .menus import PauseMenu
-from .visuals import ShowText
+from .visuals import BackgroundTint
 
 
 
@@ -248,7 +248,8 @@ class Play(State):
 
     def _pause_game(self) -> None:
         "Adds PauseMenu state to state stack as well as some background tint."
-        PauseMenu(self.__background_tint).add_to_stack(self.state_stack)
+        BackgroundTint(self.__background_tint).add_to_stack(self.state_stack)
+        PauseMenu().add_to_stack(self.state_stack)
 
 
     def _respawn_player(self) -> None:

--- a/src/states/play_level.py
+++ b/src/states/play_level.py
@@ -146,7 +146,9 @@ class PlayLevel(Play):
             self._draw_entities(surface, lerp_amount)# if self.spaceship.health else 1)
 
 
-        if self.spaceship.health or self._player_lives:
+        if ((self.spaceship.health or self._player_lives)
+            and (self.is_top_state() or len(self.state_stack) == 3)):
+
             self._draw_hud(surface)
 
 
@@ -159,9 +161,6 @@ class PlayLevel(Play):
 
 
     def _draw_hud(self, surface: pg.Surface) -> None:
-        if not self.is_top_state() and not self.state_stack[-2] is self:
-            return
-
         if not self.__hud_timer.complete:
             entrance_offset = 80*(self.__hud_timer.countdown*0.1)**2
         else:
@@ -236,7 +235,12 @@ class PlayLevel(Play):
     
     def _game_over(self) -> None:
         "Updates the score and shows the game over screen."
-        self.__set_score()
+        if debug.Cheats.instant_restart:
+            self.state_stack.quit()
+            from src.states.init_state import Initializer
+            Initializer.main_gameplay(self.state_stack)
+            return
+
         for obj in self.entities.sprites():
             if isinstance(obj, components.ObjectVelocity):
                 obj.set_velocity((0, 0))
@@ -244,6 +248,7 @@ class PlayLevel(Play):
             if isinstance(obj, components.ObjectTexture):
                 obj.set_angular_vel(0)
 
+        self.__set_score()
         GameOverScreen(self._level_data.level_name, (self.__display_score, self.highscore, self.highscore_changed)).add_to_stack(self.state_stack)
 
 


### PR DESCRIPTION
Revert back to using the `BackgroundTint` state instead of called the `add_background_tint`function in draw methods of states.

Add new state `DebugMenu` that allows me to toggle cheats while game is running. Accessed by pressing Q while in settings and when `DEBUG_MODE` is set to True. 